### PR TITLE
Only umbrella super types are included in query

### DIFF
--- a/includes/class-linked-events.php
+++ b/includes/class-linked-events.php
@@ -218,7 +218,10 @@ class Linked_Events
 
 	protected function defaultQueryArgs( string $query_url ): array
 	{
-		$args = array( 'format' => 'json' );
+		$args = array(
+			'format' => 'json',
+			'super_event_type' => 'umbrella,none',
+		);
 
 		$api_key = apply_filters(
 			'linked_events_api_key',


### PR DESCRIPTION
- There are two type of parent events with sub events: umbrella and recurring. Recurring events' parents are now left out as requested.